### PR TITLE
Fix Chinese characters not displaying properly in rank title text

### DIFF
--- a/RankMarshal.toc
+++ b/RankMarshal.toc
@@ -1,5 +1,5 @@
-## Interface: 11506
-## Version: 1.1.0
+## Interface: 11507
+## Version: 1.2.1
 ## Title: Rank Marshal
 ## Notes: Replaces the honor window with a user-friendly interface for tracking your rank progress.
 ## Author: Dildore

--- a/RankMarshalTemplates.xml
+++ b/RankMarshalTemplates.xml
@@ -90,9 +90,8 @@
 				</Anchors>
 				<Layers>
 					<Layer level="ARTWORK">
-						<FontString name="$parentText" font="Fonts\FRIZQT__.TTF" text="Loading..." justifyH="LEFT" justifyV="TOP">
+						<FontString name="$parentText" inherits="GameFontNormalLarge" text="Loading..." justifyH="LEFT" justifyV="TOP">
 							<Color r="1.0" g="0.82" b="0" />
-							<FontHeight val="14" />
 							<Anchors>
 								<Anchor point="CENTER" relativeTo="$parent" relativePoint="CENTER" x="0" y="0" />
 							</Anchors>


### PR DESCRIPTION
Rank title FontStrings were using `Fonts\FRIZQT__.TTF` which doesn't support Chinese characters:
![image](https://github.com/user-attachments/assets/beb63ab9-6c88-4436-a6cd-f6f80912f393)

Changed the FontString to inherit from `GameFontNormalLarge` which will set the font appropriately for the locale.